### PR TITLE
Allow multiple roles and fix project_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,20 @@ It is built on top of the SQL assignment backend.
 
 ### Installation
 
-Edit the `hybrid_assignment.py` file in this project and set the `DEFAULT_PROJECT`, `DEFAULT_ROLE` and `DEFAULT_DOMAIN` constants at the top of the file. The corresponding objects should already exist in the database!
-
-Then copy the edited `hybrid_assignment.py` file to the `keystone/identity/backends/` folder of your installation (e.g. `/usr/lib/python/site-packages/keystone/assignment/backends/hybrid_assignment.py`).
-
+Copy `hybrid_assignment.py` to the `keystone/identity/backends/` folder of your installation (e.g. `/usr/lib/python/site-packages/keystone/assignment/backends/hybrid_assignment.py`).
 
 Set this in your `keystone.conf` file:
 
 ```
 [assignment]
 driver = keystone.assignment.backends.hybrid_assignment.Assignment
+
+[ldap_hybrid]
+default_roles = _member_
+default_project = demo
+default_domain = default
 ```
+Where ```default_roles``` takes a comma separated list of strings.
+The corresponding objects should already exist in the database!
 
 Restart keystone.

--- a/hybrid_assignment.py
+++ b/hybrid_assignment.py
@@ -1,3 +1,4 @@
+# Copyright 2014 Hewlett-Packard Development Company, L.P.
 # Copyright 2014 SUSE Linux Products GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -12,17 +13,32 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from oslo.config import cfg
+from keystone import config
 from keystone.assignment.backends import sql as sql_assign
 from keystone.common import sql
 from keystone import exception
+from keystone.openstack.common.gettextutils import _
 
-DEFAULT_PROJECT = 'openstack'
-DEFAULT_ROLE = 'Member'
-DEFAULT_DOMAIN = 'default'
+
+hybrid_opts = [
+    cfg.ListOpt('default_roles',
+                default=['_member_', ],
+                help='List of roles assigned by default to an LDAP user'),
+    cfg.StrOpt('default_project',
+               default='demo',
+               help='Default project'),
+    cfg.StrOpt('default_domain',
+               default='default',
+               help='Default domain'),
+]
+
+CONF = config.CONF
+CONF.register_opts(hybrid_opts, 'ldap_hybrid')
 
 
 class Assignment(sql_assign.Assignment):
-    _default_role = None
+    _default_roles = list()
     _default_project = None
 
     def _get_metadata(self, user_id=None, tenant_id=None,
@@ -31,32 +47,59 @@ class Assignment(sql_assign.Assignment):
             res = super(Assignment, self)._get_metadata(
                 user_id, tenant_id, domain_id, group_id, session)
         except exception.MetadataNotFound:
-            if self.default_project == tenant_id:
-                return {'roles': [{'id': self.default_role}]}
+            if self.default_project_id == tenant_id:
+                return {
+                    'roles': [
+                        {'id': role_id} for role_id in self.default_roles
+                    ]
+                }
             else:
                 raise
         else:
             roles = res.get('roles', [])
-            roles.append({'id': self.default_role})
-            res['roles'] = roles
+            res['roles'] = roles + [
+                {'id': role_id} for role_id in self.default_roles
+            ]
             return res
 
     @property
     def default_project(self):
         if self._default_project is None:
             self._default_project = self.get_project_by_name(
-                DEFAULT_PROJECT, DEFAULT_DOMAIN)['id']
-        return self._default_project
+                CONF.ldap_hybrid.default_project,
+                CONF.ldap_hybrid.default_domain)
+        return dict(self._default_project)
 
     @property
-    def default_role(self):
-        if self._default_role is None:
-            session = sql.get_session()
-            try:
-                role = session.query(sql_assign.Role).filter_by(
-                    name=DEFAULT_ROLE).one()
-            except sql.NotFound:
-                raise exception.RoleNotFound(role_id=DEFAULT_ROLE)
-            self._default_role = role.id
+    def default_project_id(self):
+        return self.default_project['id']
 
-        return self._default_role
+    @property
+    def default_roles(self):
+        if not self._default_roles:
+            with sql.transaction() as session:
+                query = session.query(sql_assign.Role)
+                query = query.filter(sql_assign.Role.name.in_(
+                    CONF.ldap_hybrid.default_roles))
+                role_refs = query.all()
+
+            if len(role_refs) != len(CONF.ldap_hybrid.default_roles):
+                raise exception.RoleNotFound(
+                    message=_('Could not find one or more roles: %s') %
+                    ', '.join(CONF.ldap_hybrid.default_roles))
+
+            self._default_roles = [role_ref.id for role_ref in role_refs]
+        return self._default_roles
+
+    def list_projects_for_user(self, user_id, group_ids, hints):
+        projects = super(Assignment, self).list_projects_for_user(
+            user_id, group_ids, hints)
+
+        # Make sure the default project is in the project list for the user
+        # user_id
+        for project in projects:
+            if project.id == self.default_project_id:
+                return projects
+
+        projects.append(self.default_project)
+        return projects


### PR DESCRIPTION
This change includes:
- assignment of multiple roles for a given project;
- fix project_list when roles are assigned with this module;
- takes roles, project and domain parameters from keystone
  configuration rather than using hardcoded values.
