### PR TITLE
Hacky fix for issue #17 and #20.

### DIFF
--- a/hybrid_identity.py
+++ b/hybrid_identity.py
@@ -101,8 +101,9 @@ class Identity(sql_ident.Identity):
             user_ref = super(Identity, self)._get_user(session, user_id)
         except exception.UserNotFound:
             # then try LDAP
-            return self.user.get(user_id)
+            user_ref = self.user.get(user_id)
             user_ref['domain_id'] = u'default'
+            return user_ref
         else:
             return user_ref
 

--- a/hybrid_identity.py
+++ b/hybrid_identity.py
@@ -102,6 +102,7 @@ class Identity(sql_ident.Identity):
         except exception.UserNotFound:
             # then try LDAP
             return self.user.get(user_id)
+            user_ref['domain_id'] = u'default'
         else:
             return user_ref
 


### PR DESCRIPTION
Inserts fake domain_id value for LDAP users, but only for calls to _get_user() (used primarily during authentication)
Getting list of users will not return the fake domain_id value.
