### PR TITLE
Fix project dictionary access

### DIFF
--- a/hybrid_assignment.py
+++ b/hybrid_assignment.py
@@ -98,7 +98,7 @@ class Assignment(sql_assign.Assignment):
         # Make sure the default project is in the project list for the user
         # user_id
         for project in projects:
-            if project.id == self.default_project_id:
+            if project['id'] == self.default_project_id:
                 return projects
 
         projects.append(self.default_project)


### PR DESCRIPTION
The `project` variable returned by the SQL backend is a dictionary (as opposed to a proper model in the LDAP backend). Verified in icehouse and juno.

```
[-] 'dict' object has no attribute 'id'
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/keystone/common/wsgi.py", line 223, in __call__
    result = method(context, **params)
  File "/usr/lib/python2.7/site-packages/keystone/assignment/controllers.py", line 81, in get_projects_for_token
    self.assignment_api.list_projects_for_user(token_ref.user_id))
  File "/usr/lib/python2.7/site-packages/keystone/assignment/core.py", line 309, in list_projects_for_user
    user_id, group_ids, hints or driver_hints.Hints())
  File "/usr/lib/python2.7/site-packages/keystone/assignment/backends/hybrid_assignment.py", line 101, in list_projects_for_user
    if project.id == self.default_project_id:
AttributeError: 'dict' object has no attribute 'id'
```
