### PR TITLE
Automatically create tenants/projects from LDAP

### DIFF
--- a/hybrid_assignment.py
+++ b/hybrid_assignment.py
@@ -98,7 +98,7 @@ class Assignment(sql_assign.Assignment):
         # Make sure the default project is in the project list for the user
         # user_id
         for project in projects:
-            if project.id == self.default_project_id:
+            if project.get('id') == self.default_project_id:
                 return projects
 
         projects.append(self.default_project)

--- a/hybrid_assignment.py
+++ b/hybrid_assignment.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Hewlett-Packard Development Company, L.P
+# Copyright 2014 Hewlett-Packard Development Company, L.P.
 # Copyright 2014 SUSE Linux Products GmbH
 # Copyright 2015 IBM Corp.
 #

--- a/hybrid_assignment.py
+++ b/hybrid_assignment.py
@@ -1,5 +1,6 @@
-# Copyright 2014 Hewlett-Packard Development Company, L.P.
+# Copyright 2014 Hewlett-Packard Development Company, L.P
 # Copyright 2014 SUSE Linux Products GmbH
+# Copyright 2015 IBM Corp.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -13,12 +14,24 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from __future__ import absolute_import
+
+import ldap
+
 from oslo.config import cfg
 from keystone import config
+from keystone.assignment.backends import ldap as ldap_assign_backend
 from keystone.assignment.backends import sql as sql_assign
+from keystone.identity.backends import ldap as ldap_ident_backend
+from keystone.identity.backends import sql as sql_ident
 from keystone.common import sql
+from keystone.common import ldap as common_ldap
 from keystone import exception
 from keystone.openstack.common.gettextutils import _
+from keystone.openstack.common import log
+
+
+LOG = log.getLogger(__name__)
 
 
 hybrid_opts = [
@@ -40,6 +53,9 @@ CONF.register_opts(hybrid_opts, 'ldap_hybrid')
 class Assignment(sql_assign.Assignment):
     _default_roles = list()
     _default_project = None
+    identity = sql_ident.Identity()
+    ldap_assign = ldap_assign_backend.Assignment()
+    ldap_ident = ldap_ident_backend.Identity()
 
     def _get_metadata(self, user_id=None, tenant_id=None,
                       domain_id=None, group_id=None, session=None):
@@ -47,7 +63,8 @@ class Assignment(sql_assign.Assignment):
             res = super(Assignment, self)._get_metadata(
                 user_id, tenant_id, domain_id, group_id, session)
         except exception.MetadataNotFound:
-            if self.default_project_id == tenant_id:
+            projects = self._list_projects(user_id)
+            if tenant_id in [project['id'] for project in projects]:
                 return {
                     'roles': [
                         {'id': role_id} for role_id in self.default_roles
@@ -91,9 +108,59 @@ class Assignment(sql_assign.Assignment):
             self._default_roles = [role_ref.id for role_ref in role_refs]
         return self._default_roles
 
+    def _list_projects(self, user_id):
+        user_dn = self.ldap_ident.user._id_to_dn(user_id),
+        results = self.ldap_assign.role._ldap_get_list(
+                    self.ldap_assign.project.tree_dn, ldap.SCOPE_SUBTREE,
+                    query_params={self.ldap_assign.role.member_attribute:
+                                  user_dn[0]},
+                    attrlist=[
+                        CONF.ldap.project_id_attribute,
+                        CONF.ldap.project_name_attribute,
+                        CONF.ldap.project_desc_attribute,
+                    ])
+        projects = []
+        for result in results:
+            project = {
+                'description': result[1].get(CONF.ldap.project_desc_attribute)[0],
+                'domain_id': CONF.ldap_hybrid.default_domain,
+                'enabled': True,
+                'id': result[1].get(CONF.ldap.project_id_attribute)[0],
+                'name': result[1].get(CONF.ldap.project_name_attribute)[0],
+            }
+            projects.append(project)
+        return projects
+
     def list_projects_for_user(self, user_id, group_ids, hints):
-        projects = super(Assignment, self).list_projects_for_user(
-            user_id, group_ids, hints)
+        try:
+            self.identity.get_user(user_id)
+        except exception.UserNotFound:
+            projects = self._list_projects(user_id)
+            for project in projects:
+                # Check to see if the project already exists
+                try:
+                    super(Assignment, self).get_project(project['id'])
+                except:
+                    # Create the project locally
+                    try:
+                        super(Assignment, self).create_project(project['id'],
+                                                               project)
+                    except:
+                        # Don't worry if it can't be added
+                        pass
+
+                # Add the proper roles to the project
+                for role_id in self.default_roles:
+                    try:
+                        super(Assignment, self).add_role_to_user_and_project(
+                                user_id, project['id'], role_id)
+                    except:
+                        # Don't worry, the role probably has already been added
+                        pass
+
+        else:
+            projects = super(Assignment, self).list_projects_for_user(
+                user_id, group_ids, hints)
 
         # Make sure the default project is in the project list for the user
         # user_id
@@ -101,5 +168,8 @@ class Assignment(sql_assign.Assignment):
             if project.get('id') == self.default_project_id:
                 return projects
 
-        projects.append(self.default_project)
+        if not projects:
+            # Only add the default project if they aren't already assigned
+            projects.append(self.default_project)
+
         return projects

--- a/hybrid_assignment.py
+++ b/hybrid_assignment.py
@@ -111,18 +111,19 @@ class Assignment(sql_assign.Assignment):
     def _list_projects(self, user_id):
         user_dn = self.ldap_ident.user._id_to_dn(user_id),
         results = self.ldap_assign.role._ldap_get_list(
-                    self.ldap_assign.project.tree_dn, ldap.SCOPE_SUBTREE,
-                    query_params={self.ldap_assign.role.member_attribute:
-                                  user_dn[0]},
-                    attrlist=[
-                        CONF.ldap.project_id_attribute,
-                        CONF.ldap.project_name_attribute,
-                        CONF.ldap.project_desc_attribute,
-                    ])
+            self.ldap_assign.project.tree_dn, ldap.SCOPE_SUBTREE,
+            query_params={self.ldap_assign.role.member_attribute:
+                          user_dn[0]},
+            attrlist=[
+                CONF.ldap.project_id_attribute,
+                CONF.ldap.project_name_attribute,
+                CONF.ldap.project_desc_attribute,
+            ])
         projects = []
         for result in results:
             project = {
-                'description': result[1].get(CONF.ldap.project_desc_attribute)[0],
+                'description':
+                    result[1].get(CONF.ldap.project_desc_attribute)[0],
                 'domain_id': CONF.ldap_hybrid.default_domain,
                 'enabled': True,
                 'id': result[1].get(CONF.ldap.project_id_attribute)[0],
@@ -153,7 +154,7 @@ class Assignment(sql_assign.Assignment):
                 for role_id in self.default_roles:
                     try:
                         super(Assignment, self).add_role_to_user_and_project(
-                                user_id, project['id'], role_id)
+                            user_id, project['id'], role_id)
                     except:
                         # Don't worry, the role probably has already been added
                         pass


### PR DESCRIPTION
Would there be any interest in this feature?

Instead of assigning users to a default project and adding the roles, the behavior is changed so that tenants/projects are fetched from LDAP and automatically created.  In addition, default roles are set for each new tenant/project for the user.

I haven't seen any problems with LDAP or performance but due to fetching groups every time a user logs in, there's potential for an issue.  That could be mitigated with caching.  I'm open to any recommendations.

If there is interest, I'll probably have to adjust things to support either a default project (original behavior) or the new behavior, but I'll wait until I know more.
