### PR TITLE
Remove the user_ref['password'] element if LDAP returns it

### DIFF
--- a/hybrid_identity.py
+++ b/hybrid_identity.py
@@ -103,6 +103,12 @@ class Identity(sql_ident.Identity):
             # then try LDAP
             user_ref = self.user.get(user_id)
             user_ref['domain_id'] = CONF.identity.default_domain_id
+            # Above we assume no password is in the user_ref:
+            # except KeyError:  # if it doesn't have a password, it must be LDAP
+            # But if the LDAP server returns a password, this except
+            # fails so we should remove it if it's there
+            if 'password' in user_ref:
+              del user_ref['password']
             return user_ref
         else:
             return user_ref


### PR DESCRIPTION
The logic for determining if a user was found in SQL is to check
to see if the key password is in the returned user_ref dict:

except KeyError:  # if it doesn't have a password, it must be LDAP

If, however, the LDAP server returns a password element, this
except will fail, causing us to attempt to validate an LDAP
user against SQL. This will almost always fail for obvious reasons.

Removing the password element if it exists in the dict returned by
LDAP alleviates this issue.
