### PR TITLE
Make assertion on checking password in SQL backend use a message

### DIFF
--- a/hybrid_identity.py
+++ b/hybrid_identity.py
@@ -57,7 +57,8 @@ class Identity(sql_ident.Identity):
         try:
             # if the user_ref has a password, it's from the SQL backend and
             # we can just check if it coincides with the one we got
-            assert utils.check_password(password, user_ref['password'])
+            assert utils.check_password(password, user_ref['password']), \
+                   'Invalid user / password'
         except TypeError:
             raise AssertionError('Invalid user / password')
         except KeyError:  # if it doesn't have a password, it must be LDAP


### PR DESCRIPTION
This matters because in Juno, we hit an error due to the missing message:

```
 [-] tuple index out of range
 Traceback (most recent call last):
   File "/usr/lib64/python2.6/site-packages/keystone/common/wsgi.py", line 223, in __call__
     result = method(context, **params)
   File "/usr/lib64/python2.6/site-packages/keystone/token/controllers.py", line 100, in authenticate
     context, auth)
   File "/usr/lib64/python2.6/site-packages/keystone/token/controllers.py", line 298, in _authenticate_local
     raise exception.Unauthorized(e.args[0])
 IndexError: tuple index out of range
```
